### PR TITLE
Modify to use M5.begin()

### DIFF
--- a/papers3badge.ino
+++ b/papers3badge.ino
@@ -9,12 +9,9 @@
 // to let you know the device is powered on. While the dot is TFT_WHITE, 
 // double click the power button to power it off.
 
-#include <epdiy.h>
-#include <M5GFX.h>
 #include <M5Unified.h>
 #include "IMG_0573.h"
 
-M5GFX display;
 int pixel[3];
 char *data;
 int color = 0;
@@ -22,37 +19,40 @@ int color = 0;
 
 void setup(void)
 {
-  display.init();
-  display.setTextSize(5.0);
-  if (display.isEPD())
+  auto cfg = M5.config();
+  cfg.serial_baudrate = 115200;
+  M5.begin(cfg);
+
+  M5.Display.setTextSize(5.0);
+  if (M5.Display.isEPD())
   {
-    display.setEpdMode(epd_mode_t::epd_fastest);
+    M5.Display.setEpdMode(epd_mode_t::epd_fastest);
   }
   // eyelet at top
-  display.setRotation(display.getRotation() ^ 2);
+  M5.Display.setRotation(M5.Display.getRotation() ^ 2);
   // Crashes here, do not use: M5.begin();
   //M5.Speaker.setVolume(255);
   //M5.Speaker.tone(2000, 100); 
-  display.println("I RUN");
+  M5.Display.println("I RUN");
   
-  display.startWrite();
-  display.fillScreen(TFT_WHITE);
-  display.drawXBitmap(0, 0, xbm_bits, xbm_width, xbm_height, TFT_BLACK);
-  display.endWrite();
+  M5.Display.startWrite();
+  M5.Display.fillScreen(TFT_WHITE);
+  M5.Display.drawXBitmap(0, 0, xbm_bits, xbm_width, xbm_height, TFT_BLACK);
+  M5.Display.endWrite();
 }
 
 void loop(void)
 {
-  display.startWrite();
+  M5.Display.startWrite();
   if (color == 0)
   {
-     display.fillCircle(500,910,20,TFT_WHITE);
+     M5.Display.fillCircle(500,910,20,TFT_WHITE);
   }
   else
   {
-     display.fillCircle(500,910,20,TFT_BLACK);
+     M5.Display.fillCircle(500,910,20,TFT_BLACK);
   }
-  display.endWrite();
+  M5.Display.endWrite();
   color = (color + 1) % 2;
   sleep(3);
 }


### PR DESCRIPTION
I guess your code is based on the BarGraph example, correct?

Well, I think the crash happens due to ending up with two displays, e.g. display and M5.Display.

Modifying the code to only use M5.Display fixes the crash.